### PR TITLE
better AVLTree::Erase

### DIFF
--- a/2023/AlgoICT2Sem/avl_tree.cpp
+++ b/2023/AlgoICT2Sem/avl_tree.cpp
@@ -92,24 +92,27 @@ class AVLTree {
         node->left = Erase(node->left, key);
         return Balance(node);
       }
-      if (key > node->key) {
-        node->right = Erase(node->right, key);
+
+      if (key == node->key) {
+        --size_;
+        if (node->right == nullptr) {
+          Node* left_child = node->left;
+          delete node;
+          return left_child;
+        }
+
+        Node* right_min = FindMin(node->right);
+        node->right = DetachMin(node->right);
+        std::swap(right_min->key, node->key);
+        std::swap(right_min->value, node->value);
+        delete right_min;
         return Balance(node);
       }
 
-      --size_;
-      if (node->right == nullptr) {
-        Node* left_child = node->left;
-        delete node;
-        return left_child;
-      }
-
-      Node* right_min = FindMin(node->right);
-      node->right = DetachMin(node->right);
-      std::swap(right_min->key, node->key);
-      std::swap(right_min->value, node->value);
-      delete right_min;
+      //if (key > node->key) {
+      node->right = Erase(node->right, key);
       return Balance(node);
+      //}
     }
 
     Node* Balance(Node* node) {


### PR DESCRIPTION
In the implementation of [AVLTree](https://github.com/VladislavHacker/MiptExamples/blob/main/2023/AlgoICT2Sem/avl_tree.cpp) type template `KeyT` is used. We could require only implementation of `KeyT::operator==` and `KeyT::operator<`, where also `KeyT::operator>` is required now.

https://github.com/VladislavHacker/MiptExamples/blob/c1310b5ad582df98b7953166209370a75d1db9fd/2023/AlgoICT2Sem/avl_tree.cpp#L95

In all other parts of [avl_tree.cpp](https://github.com/VladislavHacker/MiptExamples/blob/main/2023/AlgoICT2Sem/avl_tree.cpp) only `KeyT::operator==` and `KeyT::operator<` are needed. Also, such libraries as **std** often require only `operator<` without `operator>`.
